### PR TITLE
fixes "Cannot call method 'split' of null" error

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,10 @@
               var test = findByName(suite.tests, result.description, Test);
               var brwsr = findByName(test.browsers, browser.name, Browser);
 
-              brwsr.errors = result.log[0].split('\n');
+
+              if(result.log[0] !== null){
+                brwsr.errors = result.log[0].split('\n');
+              }
 
             // Otherwise, keep looping through sub-suites
             } else {


### PR DESCRIPTION
Was getting this error:

```
ERROR [karma]: [TypeError: Cannot call method 'split' of null]_-_-_-_-_-_-_-_-_-_,------,
  TypeError: Cannot call method 'split' of null-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_|   /\_/\
at /project/node_modules/karma-nyan-reporter/index.js:140:46
at Array.forEach (native)-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-  ""  ""
at NyanCat.self.onSpecComplete (/project/node_modules/karma-nyan-reporter/index.js:128:24)
at null.<anonymous> (/project/node_modules/karma/lib/events.js:15:22)
at emit (events.js:98:17)
at onResult (/project/node_modules/karma/lib/browser.js:213:13)
at Socket.<anonymous> (/project/node_modules/karma/lib/events.js:15:22)
at Socket.emit [as $emit] (events.js:117:20)
at SocketNamespace.handlePacket (/project/node_modules/karma/node_modules/socket.io/lib/namespace.js:335:22)
at Manager.onClientMessage (/project/node_modules/karma/node_modules/socket.io/lib/manager.js:518:38)
```

on this test:

``` js
var Utility = {};
    Utility.capitalize = function(str){
      if(typeof str !== 'string'){return str;}
      return str.charAt(0).toUpperCase() + str.slice(1);
    };

var allTypes = {
  string : 'string'
  , caps : 'String'
  , camel: 'aStringOfStuff'
  , spaces: 'a string of stuff'
  , specialCharacters : '!@#$%^&*()_=-`{}|\\][;\':"<>?/.,¢∞§ªº–≠'
  , fn : function(){}
  , factory : function(){ return function(){} }()
  , num : 123
  , bool : true
  , boolf : false
  , boolo : 1
  , boolz : 0
  , nl : null
  , undf : ''
  , obj : {}
  , arr : []
};

describe('The Utility Service', function() {
  it ('is defined', function () {
    expect (Utility).toExist ();
  });
  describe ("Utility has a", function () {
    it ('capitalize function which will capitalize the first letter', function () {
      var result = Utility.capitalize (allTypes.caps);

      expect (result).toBe (allTypes.string);
      console.log (allTypes.string);

      expect (result).toBe (allTypes.string);
      expect (result).toBe (allTypes.caps);
      expect (result).not.toBe (allTypes.string);
    });
  });
});

```

solution was to check for null before attempting split.
