### PR TITLE
Simple 'options' logic + "suppressStackTrace" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,26 @@ Here is a screenshot of the error and logging output. The errors are displayed h
 
 ![alt text](https://googledrive.com/host/0BxhEGuYWG8zAWHlxTmtNbWtibEE/karma-nyan-reporter-errors.png "Nyan Cat Reporter Error Output")
 
+Options
+=========
+
+If you want to supress the stack trace at the end of the test run you can use the suppressStackTrace option.
+
+```js
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+    // normal config stuffs
+
+    reporters: ['nyan'],
+
+    // reporter options
+    nyanReporter: {
+      suppressStackTrace: true
+    }
+  });
+};
+```
 
 In this release
 -----------

--- a/index.js
+++ b/index.js
@@ -3,6 +3,11 @@
   'use strict';
   var tty = require('tty');
   var clc = require('cli-color');
+  var defaultOptions = function(){
+    return {
+      suppressStackTrace: false
+    };
+  };
 
   // Emulate the Mocha base class a little bit
   // just to get things going
@@ -52,6 +57,15 @@
    var Base = new BaseClass();
 
   function NyanCat(baseReporterDecorator, formatError, config) {
+    var options = defaultOptions();
+    if ( config && config.nyanReporter ) {
+      // merge defaults
+      Object.keys( options ).forEach(function(optionName){
+        if ( config.nyanReporter.hasOwnProperty(optionName) ) {
+          options[optionName] = config.nyanReporter[optionName];
+        }
+      });
+    }
 
     var width = Base.window.width * 0.75 | 0;
     var self = this;
@@ -186,7 +200,7 @@
 
         Base.cursor.show();
 
-        if (self.errors.length) {
+        if (!options.suppressStackTrace && self.errors.length) {
           write(clc.red('Failed Tests:\n'));
           printSuitesArray(self.errors, 'red');
         }


### PR DESCRIPTION
The way my testing workflow is set up I don't need to see the full stack trace of errors in the console (the stack traces are reachable elsewhere). Since I wanted to give my developers a little treat and use karma-nyan-reporter in the console I added an option to suppress the stack trace all together.

Since there was no option system set up I added a little bit of functionality to create a defaultOptions object and merge that with any incoming options from the "config" object passed in by Karma.

The reasoning for using a function and returning a new instance of "defaultOptions" is in the unlikely event that two NyanCat instances are created, their options objects won't conflict.

If you have any suggestions or changes or just don't like this/me please let me know.