### PR TITLE
fix for dgarlitt/karma-nyan-reporter/issues/10

### DIFF
--- a/lib/nyanCat.js
+++ b/lib/nyanCat.js
@@ -5,6 +5,7 @@ var drawUtil = require('./util/draw');
 var printers = require('./util/printers');
 var rainbowifier = require('./util/rainbowifier');
 var shellUtil = require('./util/shell').getInstance();
+var fs = require('fs');
 
 /**
  * NyanCat constructor
@@ -30,11 +31,7 @@ function NyanCat(baseReporterDecorator, formatError, config) {
     });
   }
 
-  self.adapterMessages = [];
-
-  self.adapters = [function(msg) {
-    self.adapterMessages.push(msg);
-  }];
+  self.adapters = [fs.writeSync.bind(fs.writeSync, 1)];
 }
 
 

--- a/test/nyanCat.test.js
+++ b/test/nyanCat.test.js
@@ -90,7 +90,7 @@ describe('nyanCat.js test suite', function() {
     };
 
     defaultPropertyKeys = [
-      'options', 'adapterMessages', 'adapters'
+      'options', 'adapters'
     ];
 
     module = rewire('../lib/nyanCat');
@@ -139,9 +139,6 @@ describe('nyanCat.js test suite', function() {
       expect(sut.adapters[0]).to.be.a.function;
 
       sut.adapters[0](msg);
-
-      expect(sut.adapterMessages).to.have.length(1);
-      expect(sut.adapterMessages[0]).to.equal(msg);
     });
 
     it('should set options when passed in via config', function() {


### PR DESCRIPTION
fix for dgarlitt/karma-nyan-reporter/issues/10

I digged a little and found the real problem.
Problem occured only when you run with `--single-run` flag.
Because nyan-reporter used `adapterMessages` which caused to dump log message not directly to the console, but to the memory and later on to the console. When karma runner ends its work, then it erases not dumped memory content.
To fix that I used direct `fs.writeSync` instead of `adapterMessages`.

Fixed tests as well.

Some references to this problem from other karma reporters:
https://github.com/karma-runner/karma-teamcity-reporter/issues/5