### PR TITLE
maxLogLines flag for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,12 @@ module.exports = function(config) {
       // only render the graphic after all tests have finished.
       // This is ideal for using this reporter in a continuous
       // integration environment.
-      renderOnRunCompleteOnly: true // default is false
+      renderOnRunCompleteOnly: true, // default is false
+
+      // limit the number of lines of error shown
+      // No error occurs if this limit is longer than 
+      // the number of lines reported.
+      maxLogLines: 5 // default is 9001
     }
   });
 };

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ module.exports = function(config) {
       // limit the number of lines of error shown
       // No error occurs if this limit is longer than 
       // the number of lines reported.
-      maxLogLines: 5 // default is 9001
+      maxLogLines: 5 // default is unlimited
     }
   });
 };

--- a/lib/data/types.js
+++ b/lib/data/types.js
@@ -15,9 +15,9 @@ var tab = 3;
 var tabs = function(depth) {
   return clc.right(depth * tab + 1);
 };
-var maxLines = 9001;
 
 var errorHighlightingEnabled = true;
+var maxLines;
 
 exports.suppressErrorHighlighting = function() {
   errorHighlightingEnabled = false;
@@ -33,7 +33,7 @@ exports.setErrorFormatterMethod = function(formatterMethod) {
 
 exports.setMaxLogLines = function(maxLogLines) {
   maxLines = maxLogLines;
-}
+};
 
 /**
  * Suite - Class
@@ -125,7 +125,9 @@ Browser.prototype.toString = function() {
 
   out.push(tabs(this.depth) + clc.yellow(this.name));
 
-  this.errors = this.errors.slice(0, maxLines);
+  if (this.errors) {
+    this.errors = this.errors.slice(0, maxLines);
+  }
 
   this.errors.forEach(function(error, i) {
     error = error.trim();

--- a/lib/data/types.js
+++ b/lib/data/types.js
@@ -135,8 +135,6 @@ Browser.prototype.toString = function() {
 
       error = errorFormatterMethod(error).trim();
 
-
-
       if (error.length) {
         if (error.indexOf('node_modules/') < 0 && errorHighlightingEnabled) {
           error = clc.black.bgRed(error);

--- a/lib/data/types.js
+++ b/lib/data/types.js
@@ -125,7 +125,7 @@ Browser.prototype.toString = function() {
 
   out.push(tabs(this.depth) + clc.yellow(this.name));
 
-  if (this.errors) {
+  if (this.errors && maxLines) {
     this.errors = this.errors.slice(0, maxLines);
   }
 

--- a/lib/data/types.js
+++ b/lib/data/types.js
@@ -15,6 +15,7 @@ var tab = 3;
 var tabs = function(depth) {
   return clc.right(depth * tab + 1);
 };
+var maxLines = 9001;
 
 var errorHighlightingEnabled = true;
 
@@ -29,6 +30,10 @@ var errorFormatterMethod = function(error) {
 exports.setErrorFormatterMethod = function(formatterMethod) {
   errorFormatterMethod = formatterMethod;
 };
+
+exports.setMaxLogLines = function(maxLogLines) {
+  maxLines = maxLogLines;
+}
 
 /**
  * Suite - Class
@@ -120,6 +125,8 @@ Browser.prototype.toString = function() {
 
   out.push(tabs(this.depth) + clc.yellow(this.name));
 
+  this.errors = this.errors.slice(0, maxLines);
+
   this.errors.forEach(function(error, i) {
     error = error.trim();
     if (i === 0) {
@@ -127,6 +134,8 @@ Browser.prototype.toString = function() {
     } else {
 
       error = errorFormatterMethod(error).trim();
+
+
 
       if (error.length) {
         if (error.indexOf('node_modules/') < 0 && errorHighlightingEnabled) {

--- a/lib/nyanCat.js
+++ b/lib/nyanCat.js
@@ -19,7 +19,8 @@ function NyanCat(baseReporterDecorator, formatError, config) {
       suppressErrorReport: false,
       suppressErrorHighlighting: false,
       numberOfRainbowLines: 4,
-      renderOnRunCompleteOnly: false
+      renderOnRunCompleteOnly: false,
+      maxLogLines: 42
     };
   };
 
@@ -36,6 +37,8 @@ function NyanCat(baseReporterDecorator, formatError, config) {
 
   self.adapters = [fs.writeSync.bind(fs.writeSync, 1)];
   dataTypes.setErrorFormatterMethod(formatError);
+
+  dataTypes.setMaxLogLines(self.options.maxLogLines);
 
   if (self.options.suppressErrorHighlighting) {
     dataTypes.suppressErrorHighlighting();

--- a/lib/nyanCat.js
+++ b/lib/nyanCat.js
@@ -20,7 +20,7 @@ function NyanCat(baseReporterDecorator, formatError, config) {
       suppressErrorHighlighting: false,
       numberOfRainbowLines: 4,
       renderOnRunCompleteOnly: false,
-      maxLogLines: 42
+      maxLogLines: null
     };
   };
 
@@ -38,7 +38,9 @@ function NyanCat(baseReporterDecorator, formatError, config) {
   self.adapters = [fs.writeSync.bind(fs.writeSync, 1)];
   dataTypes.setErrorFormatterMethod(formatError);
 
-  dataTypes.setMaxLogLines(self.options.maxLogLines);
+  if (self.options.maxLogLines) {
+    dataTypes.setMaxLogLines(self.options.maxLogLines);
+  }
 
   if (self.options.suppressErrorHighlighting) {
     dataTypes.suppressErrorHighlighting();

--- a/test/data.types.test.js
+++ b/test/data.types.test.js
@@ -8,9 +8,9 @@ chai.config.includeStack = true;
 chai.use(require('sinon-chai'));
 
 var assert = chai.assert;
+var expect = chai.expect;
 var eq = assert.equal;
 var ok = assert.ok;
-
 
 describe('data/types.js test suite', function() {
   var dt, clcFake, right;
@@ -247,6 +247,36 @@ describe('data/types.js test suite', function() {
         sut.toString();
 
         ok(clcFake.blackBright.calledTwice);
+      });
+    });
+
+    describe('setMaxLogLines', function() {
+      it('should set limit to lines when setMaxLogLines is called', function() {
+        dt.setMaxLogLines(3);
+        sut.errors = [
+          'Error Info',
+          'line 1',
+          'line 2',
+          'line 3',
+          'line 4',
+          'line 5'
+        ];
+
+        sut.toString();
+
+        ok(clcFake.black.bgRed.calledTwice);
+        ok(clcFake.black.bgRed.getCall(0).calledWithExactly('line 1'));
+        ok(clcFake.black.bgRed.getCall(1).calledWithExactly('line 2'));
+        expect(clcFake.black.bgRed.getCall(2)).to.be.null;
+      });
+
+      it('should not error out when there are no errors', function() {
+        dt.setMaxLogLines(3);
+        sut.errors = [];
+
+        sut.toString();
+
+        expect(clcFake.black.bgRed.getCall(0)).to.be.null;
       });
     });
 

--- a/test/nyanCat.test.js
+++ b/test/nyanCat.test.js
@@ -76,7 +76,8 @@ describe('nyanCat.js test suite', function() {
 
     dataTypesFake = {
       'setErrorFormatterMethod' : sinon.spy(),
-      'suppressErrorHighlighting' : sinon.spy()
+      'suppressErrorHighlighting' : sinon.spy(),
+      'setMaxLogLines' : sinon.spy()
     };
 
     printersFake = {
@@ -153,6 +154,7 @@ describe('nyanCat.js test suite', function() {
       expect(sut.adapters[0]).to.be.a.function;
       expect(dataTypesFake.setErrorFormatterMethod.calledOnce).to.be.true;
       expect(dataTypesFake.setErrorFormatterMethod.calledWithExactly(formatterFake)).to.be.true;
+      expect(dataTypesFake.setMaxLogLines.calledOnce).to.be.true;
 
       sut.adapters[0](msg);
     });
@@ -163,6 +165,7 @@ describe('nyanCat.js test suite', function() {
         'suppressErrorHighlighting' : true,
         'numberOfRainbowLines' : 100,
         'renderOnRunCompleteOnly' : true,
+        'maxLogLines' : 9001,
         'someOtherOption' : 1234
       };
 
@@ -172,6 +175,7 @@ describe('nyanCat.js test suite', function() {
       expect(sut.options.suppressErrorHighlighting).to.be.true;
       expect(sut.options.numberOfRainbowLines).to.eq(100);
       expect(sut.options.renderOnRunCompleteOnly).to.be.true;
+      expect(sut.options.maxLogLines).to.eq(9001);
       expect(sut.options.someOtherOption).to.be.undefined;
     });
 
@@ -183,6 +187,16 @@ describe('nyanCat.js test suite', function() {
       sut = new module.NyanCat(null, null, configFake);
 
       expect(dataTypesFake.suppressErrorHighlighting.calledOnce).to.be.true;
+    });
+
+    it('should set limit to the number of lines of error shown if option is set in config', function() {
+      configFake.nyanReporter = {
+        'maxLogLines' : 15
+      };
+
+      sut = new module.NyanCat(null, null, configFake);
+
+      expect(dataTypesFake.setMaxLogLines.calledOnce).to.be.true;
     });
 
   });

--- a/test/nyanCat.test.js
+++ b/test/nyanCat.test.js
@@ -147,6 +147,7 @@ describe('nyanCat.js test suite', function() {
       expect(sut.options.suppressErrorHighlighting).to.be.false;
       expect(sut.options.numberOfRainbowLines).to.eq(4);
       expect(sut.options.renderOnRunCompleteOnly).to.be.false;
+      expect(sut.options.maxLogLines).to.be.null;
       expect(sut.adapterMessages).to.be.an.array;
       expect(sut.adapterMessages).to.be.empty;
       expect(sut.adapters).to.be.an.array;
@@ -154,7 +155,7 @@ describe('nyanCat.js test suite', function() {
       expect(sut.adapters[0]).to.be.a.function;
       expect(dataTypesFake.setErrorFormatterMethod.calledOnce).to.be.true;
       expect(dataTypesFake.setErrorFormatterMethod.calledWithExactly(formatterFake)).to.be.true;
-      expect(dataTypesFake.setMaxLogLines.calledOnce).to.be.true;
+      expect(dataTypesFake.setMaxLogLines.called).to.be.false;
 
       sut.adapters[0](msg);
     });


### PR DESCRIPTION
Added a flag to user configuration to limit the number of lines of failed test to log

```
      // limit the number of lines of error shown
      // No error occurs if this limit is longer than 
      // the number of lines reported.
      maxLogLines: 5 // default is 9001
```

Warning, the `test.js` files have not been updated.