### PR TITLE
show previously hidden errors in final report

### DIFF
--- a/lib/data/store.js
+++ b/lib/data/store.js
@@ -38,6 +38,11 @@ DataStore.prototype.saveResultToSuite = function(suite, browser, result) {
   brwsr.depth = test.depth + 1;
 
   if(result.log && result.log[0] !== null){
+    if (result.log.length > 1) {
+      for (var i = 0; i < result.log.length; i++) {
+        result.log[0] = result.log[0] + result.log[i];
+      }
+    }
     brwsr.errors = result.log[0].split('\n');
   }
 };

--- a/lib/data/store.js
+++ b/lib/data/store.js
@@ -40,7 +40,7 @@ DataStore.prototype.saveResultToSuite = function(suite, browser, result) {
   if(result.log && result.log[0] !== null){
     if (result.log.length > 1) {
       for (var i = 0; i < result.log.length; i++) {
-        result.log[0] = result.log[0] + result.log[i];
+        result.log[0] = result.log[0] + '\n' + result.log[i];
       }
     }
     brwsr.errors = result.log[0].split('\n');


### PR DESCRIPTION
Please refer to issue 26: https://github.com/dgarlitt/karma-nyan-reporter/issues/26

Some errors don't show up, for example in an Angular 2 project, `Template parse errors` show when running the default `progress` reporter but not when running `nyan` reporter.