### PR TITLE
Remove errors that contain matching strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,12 @@ module.exports = function(config) {
       // only render the graphic after all tests have finished.
       // This is ideal for using this reporter in a continuous
       // integration environment.
-      renderOnRunCompleteOnly: true // default is false
+      renderOnRunCompleteOnly: true, // default is false
+
+      // remove lines from the final report containing any of these
+      // accepts strings. If you want to stop reporting dozens 
+      // of lines that tell you nothing of value
+      removeLinesContaining: ['@angular', 'zone.js'] // default is []
     }
   });
 };

--- a/lib/data/types.js
+++ b/lib/data/types.js
@@ -16,6 +16,8 @@ var tabs = function(depth) {
   return clc.right(depth * tab + 1);
 };
 
+var removeTheseLines = [];
+
 var errorHighlightingEnabled = true;
 
 exports.suppressErrorHighlighting = function() {
@@ -29,6 +31,10 @@ var errorFormatterMethod = function(error) {
 exports.setErrorFormatterMethod = function(formatterMethod) {
   errorFormatterMethod = formatterMethod;
 };
+
+exports.setLinesToExclude = function(linesToExclude) {
+  removeTheseLines = linesToExclude;
+}
 
 /**
  * Suite - Class
@@ -116,25 +122,36 @@ function Browser(name) {
 
 Browser.prototype.toString = function() {
   var depth = this.depth;
+  var firstElementPrinted = false;
   var out = [];
 
   out.push(tabs(this.depth) + clc.yellow(this.name));
 
   this.errors.forEach(function(error, i) {
     error = error.trim();
-    if (i === 0) {
-      out.push(tabs(depth + 1) + (++counter) + ') ' + clc.redBright(error));
-    } else {
+    error = errorFormatterMethod(error).trim();
 
-      error = errorFormatterMethod(error).trim();
+    if (error.length) {
+      var excludeThisLine = false;
 
-      if (error.length) {
-        if (error.indexOf('node_modules/') < 0 && errorHighlightingEnabled) {
-          error = clc.black.bgRed(error);
-        } else {
-          error = clc.blackBright(error);
+      removeTheseLines.forEach(function(element) {
+        if(error.indexOf(element) > -1) {
+          excludeThisLine = true
         }
-        out.push(tabs(depth + 2) + error);
+      });
+
+      if (!excludeThisLine) {
+        if (firstElementPrinted === false) {
+          out.push(tabs(depth + 1) + (++counter) + ') ' + clc.redBright(error));
+          firstElementPrinted = true;
+        } else {
+          if (error.indexOf('node_modules/') < 0 && errorHighlightingEnabled) {
+            error = clc.black.bgRed(error);
+          } else {
+            error = clc.blackBright(error);
+          }
+          out.push(tabs(depth + 2) + error);
+        }
       }
     }
   });

--- a/lib/nyanCat.js
+++ b/lib/nyanCat.js
@@ -19,7 +19,8 @@ function NyanCat(baseReporterDecorator, formatError, config) {
       suppressErrorReport: false,
       suppressErrorHighlighting: false,
       numberOfRainbowLines: 4,
-      renderOnRunCompleteOnly: false
+      renderOnRunCompleteOnly: false,
+      removeLinesContaining: []
     };
   };
 
@@ -39,6 +40,10 @@ function NyanCat(baseReporterDecorator, formatError, config) {
 
   if (self.options.suppressErrorHighlighting) {
     dataTypes.suppressErrorHighlighting();
+  }
+
+  if (self.options.removeLinesContaining) {
+    dataTypes.setLinesToExclude(self.options.removeLinesContaining);
   }
 }
 


### PR DESCRIPTION
Adds a user-editable array of strings which dictate what lines to omit from final error report.

For example:
`removeLinesContaining: ['@angular', 'zone.js']`
will remove useless error stack traces like this:
```
webpack:///~/@angular/core/@angular/core/testing.es5.js:105:0 <- src/test.ts:16390:29
onInvoke@webpack:///~/zone.js/dist/proxy.js:76:0 <- src/test.ts:95814:47
drainMicroTaskQueue@webpack:///~/zone.js/dist/zone.js:611:0 <- src/polyfills.ts:1766:28
```
_Good riddance!_

This PR does not have appropriate tests written. If you think this enhancement to the project is worthwhile, I will write the tests and resubmit, including whatever recommendations/suggestions you have.