### PR TITLE
Permit users to customize error report colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,16 @@ module.exports = function(config) {
       // only render the graphic after all tests have finished.
       // This is ideal for using this reporter in a continuous
       // integration environment.
-      renderOnRunCompleteOnly: true // default is false
+      renderOnRunCompleteOnly: true, // default is false
+
+      // set custom color options for error report
+      // will only work with numbers permitted in
+      // https://github.com/medikoo/cli-color
+      colorOptions: {
+        testName: 0,  // default is 205
+        browserName: 120, // default is 199
+        firstLine: 255 // default is 211
+      }
     }
   });
 };

--- a/lib/data/types.js
+++ b/lib/data/types.js
@@ -41,7 +41,7 @@ exports.setColorOptions = function(colorSettings) {
     colorTestName = clc.xterm(colorSettings.testName);
   }
   if (colorSettings.browserName) {
-    colorBrowser = clc.xterm(colorSettings.colorBrowser);
+    colorBrowser = clc.xterm(colorSettings.browserName);
   }
 };
 

--- a/lib/data/types.js
+++ b/lib/data/types.js
@@ -15,6 +15,9 @@ var tab = 3;
 var tabs = function(depth) {
   return clc.right(depth * tab + 1);
 };
+var colorTestName;
+var colorBrowser;
+var colorFirstLine;
 
 var errorHighlightingEnabled = true;
 
@@ -28,6 +31,18 @@ var errorFormatterMethod = function(error) {
 
 exports.setErrorFormatterMethod = function(formatterMethod) {
   errorFormatterMethod = formatterMethod;
+};
+
+exports.setColorOptions = function(colorSettings) {
+  if (colorSettings.firstLine) {
+    colorFirstLine = clc.xterm(colorSettings.firstLine);
+  }
+  if (colorSettings.testName) {
+    colorTestName = clc.xterm(colorSettings.testName);
+  }
+  if (colorSettings.browserName) {
+    colorBrowser = clc.xterm(colorSettings.colorBrowser);
+  }
 };
 
 /**
@@ -90,7 +105,7 @@ function Test(name) {
 Test.prototype.toString = function() {
   var out = [];
 
-  out.push(tabs(this.depth) + clc.red(this.name));
+  out.push(tabs(this.depth) + colorTestName(this.name));
 
   this.browsers.forEach(function(browser) {
     out.push(browser.toString().trim());
@@ -118,12 +133,12 @@ Browser.prototype.toString = function() {
   var depth = this.depth;
   var out = [];
 
-  out.push(tabs(this.depth) + clc.yellow(this.name));
+  out.push(tabs(this.depth) + colorBrowser(this.name));
 
   this.errors.forEach(function(error, i) {
     error = error.trim();
     if (i === 0) {
-      out.push(tabs(depth + 1) + (++counter) + ') ' + clc.redBright(error));
+      out.push(tabs(depth + 1) + (++counter) + ') ' + colorFirstLine(error));
     } else {
 
       error = errorFormatterMethod(error).trim();

--- a/lib/nyanCat.js
+++ b/lib/nyanCat.js
@@ -19,7 +19,12 @@ function NyanCat(baseReporterDecorator, formatError, config) {
       suppressErrorReport: false,
       suppressErrorHighlighting: false,
       numberOfRainbowLines: 4,
-      renderOnRunCompleteOnly: false
+      renderOnRunCompleteOnly: false,
+      colorOptions: {
+        testName: 199,
+        browserName: 205,
+        firstLine: 211
+      }
     };
   };
 
@@ -39,6 +44,10 @@ function NyanCat(baseReporterDecorator, formatError, config) {
 
   if (self.options.suppressErrorHighlighting) {
     dataTypes.suppressErrorHighlighting();
+  }
+
+  if (self.options.colorOptions) {
+    dataTypes.setColorOptions(self.options.colorOptions);
   }
 }
 


### PR DESCRIPTION
Permit users to customize the colors for the error report via reporter settings:
```
      // set custom color options for error report
      // will only work with numbers permitted in
      // https://github.com/medikoo/cli-color
      colorOptions: {
        testName: 0,  // default is 205
        browserName: 120, // default is 199
        firstLine: 255 // default is 211
      }
```

Please let me know if there is a good reason to keep the `clc.red(` or `clc.yellow(` rather than colors defined by numbers. 

As before, once I get feedback that my implementation is good, I will write all appropriate tests.