### PR TITLE
Adds user option to underline user-selected file type in error report

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,12 @@ module.exports = function(config) {
       // only render the graphic after all tests have finished.
       // This is ideal for using this reporter in a continuous
       // integration environment.
-      renderOnRunCompleteOnly: true // default is false
+      renderOnRunCompleteOnly: true, // default is false
+
+      // underline filename of some file type
+      // All files in the error report that have this
+      // particular extention will be underlined 
+      underlineFileType: 'spec.ts' // default is ''
     }
   });
 };

--- a/lib/data/types.js
+++ b/lib/data/types.js
@@ -15,6 +15,7 @@ var tab = 3;
 var tabs = function(depth) {
   return clc.right(depth * tab + 1);
 };
+var fileExtension;
 
 var errorHighlightingEnabled = true;
 
@@ -28,6 +29,12 @@ var errorFormatterMethod = function(error) {
 
 exports.setErrorFormatterMethod = function(formatterMethod) {
   errorFormatterMethod = formatterMethod;
+};
+
+exports.setFileTypeToUnderline = function(fileType) {
+  if(fileType) {
+    fileExtension = fileType;
+  }
 };
 
 /**
@@ -129,6 +136,16 @@ Browser.prototype.toString = function() {
       error = errorFormatterMethod(error).trim();
 
       if (error.length) {
+
+        if (fileExtension) {
+          // match everything after the last '/' and the file extension
+          var regExp = new RegExp('([^\/]*.' + fileExtension + ')');
+          var matchingFile = error.match(regExp);
+          if (matchingFile !== null) {
+            error = error.replace(matchingFile[0], colorUnderline(matchingFile[0]));
+          }
+        }
+
         if (error.indexOf('node_modules/') < 0 && errorHighlightingEnabled) {
           error = clc.black.bgRed(error);
         } else {

--- a/lib/nyanCat.js
+++ b/lib/nyanCat.js
@@ -19,7 +19,8 @@ function NyanCat(baseReporterDecorator, formatError, config) {
       suppressErrorReport: false,
       suppressErrorHighlighting: false,
       numberOfRainbowLines: 4,
-      renderOnRunCompleteOnly: false
+      renderOnRunCompleteOnly: false,
+      underlineFileType: 'spec.ts'
     };
   };
 
@@ -39,6 +40,10 @@ function NyanCat(baseReporterDecorator, formatError, config) {
 
   if (self.options.suppressErrorHighlighting) {
     dataTypes.suppressErrorHighlighting();
+  }
+
+  if (self.options.underlineFileType) {
+    dataTypes.setFileTypeToUnderline();
   }
 }
 


### PR DESCRIPTION
User can edit reporter options:
```
      // underline filename of some file type
      // All files in the error report that have this
      // particular extention will be underlined 
      underlineFileType: 'spec.ts' // default is ''
```
Using RegEx, the reporter will now find all instances of `sper.ts` in the error report and underline the full file name:
```
invoke@webpack:///~/zone.js/dist/zone.js:464:0 <- src/polyfills.ts:1619:44
timer@webpack:///~/zone.js/dist/zone.js:1655:0 <- src/polyfills.ts:2810:34
webpack:///src/app/compose/meta-tray/meta-tray.component.spec.ts:41:32 <- src/test.ts:37698:37
invoke@webpack:///~/zone.js/dist/zone.js:365:0 <- src/polyfills.ts:1520:31
onInvoke@webpack:///~/zone.js/dist/proxy.js:79:0 <- src/test.ts:95817:45
invoke@webpack:///~/zone.js/dist/zone.js:364:0 <- src/polyfills.ts:1519:40
```
Instead of hurting your eyes looking through the wall of text, you'd see the 3rd line's `meta-tray.component.spec.ts` nicely underlined