### PR TITLE
 Upgrade cli-color to 1.2.0

### DIFF
--- a/lib/data/types.js
+++ b/lib/data/types.js
@@ -13,7 +13,7 @@ var clc = require('cli-color');
 var counter = 0;
 var tab = 3;
 var tabs = function(depth) {
-  return clc.right(depth * tab + 1);
+  return clc.move.right(depth * tab + 1);
 };
 
 var errorHighlightingEnabled = true;

--- a/lib/util/draw.js
+++ b/lib/util/draw.js
@@ -97,7 +97,7 @@ function DrawUtil(numOfLines) {
   };
 
   this.cursorUp = function(n) {
-    write(clc.up(n));
+    write(clc.move.up(n));
   };
 
   this.fillWithNewlines = function(startFrom) {

--- a/lib/util/printers.js
+++ b/lib/util/printers.js
@@ -66,16 +66,16 @@ exports.printStats =
   function printStats(stats) {
     var inc = 3;
 
-    write(clc.right(inc + 2));
+    write(clc.move.right(inc + 2));
     write( clc.yellow(stats.total + ' total') );
 
-    write(clc.right(inc));
+    write(clc.move.right(inc));
     write(clc.green(stats.success + ' passed'));
 
-    write(clc.right(inc));
+    write(clc.move.right(inc));
     write(clc.red(stats.failed + ' failed'));
 
-    write(clc.right(inc));
+    write(clc.move.right(inc));
     write(clc.cyan(stats.skipped + ' skipped'));
 
     write('\n');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "url": "https://github.com/dgarlitt/karma-nyan-reporter/issues"
     },
     "dependencies": {
-        "cli-color": "^0.3.2"
+        "cli-color": "^1.2.0"
     },
     "description": "Karma reporter with Nyan Cat style logging.",
     "devDependencies": {

--- a/test/data.types.test.js
+++ b/test/data.types.test.js
@@ -20,7 +20,9 @@ describe('data/types.js test suite', function() {
     right = 'right>';
 
     clcFake = {
-      'right': sinon.stub(),
+      'move': {
+        'right': sinon.stub()
+      },
       'white': sinon.stub(),
       'red': sinon.stub(),
       'yellow': sinon.stub(),
@@ -31,7 +33,7 @@ describe('data/types.js test suite', function() {
       }
     };
 
-    clcFake.right.returns(right);
+    clcFake.move.right.returns(right);
 
     dt = rewire('../lib/data/types');
     dt.__set__('clc', clcFake);
@@ -107,8 +109,8 @@ describe('data/types.js test suite', function() {
       actual = sut.toString();
 
       eq(expected, actual);
-      ok(clcFake.right.calledOnce);
-      ok(clcFake.right.calledWithExactly(sut.depth * tab + 1));
+      ok(clcFake.move.right.calledOnce);
+      ok(clcFake.move.right.calledWithExactly(sut.depth * tab + 1));
       ok(clcFake.white.calledOnce);
       ok(clcFake.white.calledWithExactly(name));
     });
@@ -154,8 +156,8 @@ describe('data/types.js test suite', function() {
       actual = sut.toString();
 
       eq(expected, actual);
-      ok(clcFake.right.calledOnce);
-      ok(clcFake.right.calledWithExactly(depth * tab + 1));
+      ok(clcFake.move.right.calledOnce);
+      ok(clcFake.move.right.calledWithExactly(depth * tab + 1));
       ok(clcFake.red.calledOnce);
       ok(clcFake.red.calledWithExactly(name));
     });
@@ -189,11 +191,11 @@ describe('data/types.js test suite', function() {
     it('should call clc.right as expected when toString is called', function() {
       sut.toString();
 
-      eq(4, clcFake.right.callCount);
-      ok(clcFake.right.getCall(0).calledWithExactly(depth * tab + 1));
-      ok(clcFake.right.getCall(1).calledWithExactly((depth + 1) * tab + 1));
-      ok(clcFake.right.getCall(2).calledWithExactly((depth + 2) * tab + 1));
-      ok(clcFake.right.getCall(3).calledWithExactly((depth + 2) * tab + 1));
+      eq(4, clcFake.move.right.callCount);
+      ok(clcFake.move.right.getCall(0).calledWithExactly(depth * tab + 1));
+      ok(clcFake.move.right.getCall(1).calledWithExactly((depth + 1) * tab + 1));
+      ok(clcFake.move.right.getCall(2).calledWithExactly((depth + 2) * tab + 1));
+      ok(clcFake.move.right.getCall(3).calledWithExactly((depth + 2) * tab + 1));
     });
 
     it('should call the color methods on clc as expected when toString is called', function() {

--- a/test/printers.test.js
+++ b/test/printers.test.js
@@ -22,7 +22,9 @@ describe('printers.js test suite', function() {
       'redBright':    sinon.stub(),
       'cyan':         sinon.stub(),
       'green':        sinon.stub(),
-      'right':        sinon.stub(),
+      'move': {
+        'right':      sinon.stub()
+      },
       'blackBright':  sinon.stub(),
       'white':        sinon.stub(),
       'yellow':       sinon.stub()
@@ -209,7 +211,7 @@ describe('printers.js test suite', function() {
         'skipped': 99
       };
 
-      clcFake.right.returns(tab);
+      clcFake.move.right.returns(tab);
       clcFake.yellow.withArgs(stats.total + ' total').returns('yellow>' + stats.total);
       clcFake.green.withArgs(stats.success + ' passed').returns('green>' + stats.success);
       clcFake.red.withArgs(stats.failed + ' failed').returns('red>' + stats.failed);
@@ -233,10 +235,10 @@ describe('printers.js test suite', function() {
     });
 
     it('should call clc.right as expected', function() {
-      eq(4, clcFake.right.callCount);
-      ok(clcFake.right.firstCall.calledWithExactly(5));
-      ok(clcFake.right.secondCall.calledWithExactly(3));
-      ok(clcFake.right.thirdCall.calledWithExactly(3));
+      eq(4, clcFake.move.right.callCount);
+      ok(clcFake.move.right.firstCall.calledWithExactly(5));
+      ok(clcFake.move.right.secondCall.calledWithExactly(3));
+      ok(clcFake.move.right.thirdCall.calledWithExactly(3));
     });
 
     it('should call write with the expected arguments', function() {

--- a/test/util.draw.test.js
+++ b/test/util.draw.test.js
@@ -38,7 +38,9 @@ describe('util/draw.js test suite', function() {
     shellFake.getHeight.returns(shellHeight);
 
     clcFake = {
-      up: sinon.stub(),
+      move: {
+        up: sinon.stub(),
+      },
       yellow: sinon.stub(),
       green: sinon.stub(),
       red: sinon.stub(),
@@ -326,7 +328,7 @@ describe('util/draw.js test suite', function() {
     it('should call write with the expected values', function() {
       var arg = 'blah';
 
-      clcFake.up.returns('up');
+      clcFake.move.up.returns('up');
 
       sut.cursorUp(arg);
 


### PR DESCRIPTION
Depend on latest supported module versions.

The moved up, down and other moving functions to a sub-object clc.move.