### PR TITLE
Fix printing runtime errors as "[object Object]"

### DIFF
--- a/lib/util/printers.js
+++ b/lib/util/printers.js
@@ -25,7 +25,7 @@ exports.printRuntimeErrors =
         write('\n');
         write(clc.red(errorObj.browser.name));
         write('\n');
-        write(clc.red(errorObj.error));
+        write(clc.red(JSON.stringify(errorObj.error, undefined, 2)));
         write('\n');
       });
       write('\n');

--- a/lib/util/printers.js
+++ b/lib/util/printers.js
@@ -25,7 +25,7 @@ exports.printRuntimeErrors =
         write('\n');
         write(clc.red(errorObj.browser.name));
         write('\n');
-        write(clc.red(JSON.stringify(errorObj.error, undefined, 2)));
+        write(clc.red(getErrorMessage(errorObj.error)));
         write('\n');
       });
       write('\n');
@@ -38,6 +38,19 @@ exports.printRuntimeErrors =
       write('\n');
     }
   };
+
+function getErrorMessage(error) {
+  if (typeof error !== 'string') {
+    if (error.message) {
+      // If there are both error message and stacktrace inside the error message
+      error = error.message.replace(/^(?:.|\r|\n)+\r?\n\r?\n(\w*Error:)/, '$1')
+    } else {
+      // An unrecognized object
+      error = JSON.stringify(error, undefined, 2)
+    }
+  }
+  return error
+}
 
 /**
  * printTestFailures - utility method

--- a/test/printers.test.js
+++ b/test/printers.test.js
@@ -66,7 +66,16 @@ describe('printers.js test suite', function() {
         'browser': {
           'name': 'browser2'
         },
-        'error': 'error2'
+        'error': {
+          'message': 'error2'
+        }
+      },{
+        'browser': {
+          'name': 'browser3'
+        },
+        'error': {
+          'code': 'error3'
+        }
       }];
 
       out = '#,#,#,#,#,#,#,#,#,#,\n,' +
@@ -82,12 +91,17 @@ describe('printers.js test suite', function() {
             '\n,' +
             runtimeErrors[0].browser.name + ',' +
             '\n,' +
-            JSON.stringify(runtimeErrors[0].error, undefined, 2) + ',' +
+            runtimeErrors[0].error + ',' +
             '\n,' +
             '\n,' +
             runtimeErrors[1].browser.name + ',' +
             '\n,' +
-            JSON.stringify(runtimeErrors[1].error, undefined, 2) + ',' +
+            runtimeErrors[1].error.message + ',' +
+            '\n,' +
+            '\n,' +
+            runtimeErrors[2].browser.name + ',' +
+            '\n,' +
+            JSON.stringify(runtimeErrors[2].error, undefined, 2) + ',' +
             '\n,' +
             '\n,' +
             '#,\n,' +
@@ -137,11 +151,13 @@ describe('printers.js test suite', function() {
       eq(hashCount, rainbowifyFake.callCount);
       eq(total, writeFake.callCount);
 
-      eq(4, clcFake.red.callCount);
+      eq(6, clcFake.red.callCount);
       ok(clcFake.red.getCall(0).calledWithExactly(runtimeErrors[0].browser.name));
-      ok(clcFake.red.getCall(1).calledWithExactly(JSON.stringify(runtimeErrors[0].error, undefined, 2)));
+      ok(clcFake.red.getCall(1).calledWithExactly(runtimeErrors[0].error));
       ok(clcFake.red.getCall(2).calledWithExactly(runtimeErrors[1].browser.name));
-      ok(clcFake.red.getCall(3).calledWithExactly(JSON.stringify(runtimeErrors[1].error, undefined, 2)));
+      ok(clcFake.red.getCall(3).calledWithExactly(runtimeErrors[1].error.message));
+      ok(clcFake.red.getCall(4).calledWithExactly(runtimeErrors[2].browser.name));
+      ok(clcFake.red.getCall(5).calledWithExactly(JSON.stringify(runtimeErrors[2].error, undefined, 2)));
     });
   });
 

--- a/test/printers.test.js
+++ b/test/printers.test.js
@@ -82,12 +82,12 @@ describe('printers.js test suite', function() {
             '\n,' +
             runtimeErrors[0].browser.name + ',' +
             '\n,' +
-            runtimeErrors[0].error + ',' +
+            JSON.stringify(runtimeErrors[0].error, undefined, 2) + ',' +
             '\n,' +
             '\n,' +
             runtimeErrors[1].browser.name + ',' +
             '\n,' +
-            runtimeErrors[1].error + ',' +
+            JSON.stringify(runtimeErrors[1].error, undefined, 2) + ',' +
             '\n,' +
             '\n,' +
             '#,\n,' +
@@ -139,9 +139,9 @@ describe('printers.js test suite', function() {
 
       eq(4, clcFake.red.callCount);
       ok(clcFake.red.getCall(0).calledWithExactly(runtimeErrors[0].browser.name));
-      ok(clcFake.red.getCall(1).calledWithExactly(runtimeErrors[0].error));
+      ok(clcFake.red.getCall(1).calledWithExactly(JSON.stringify(runtimeErrors[0].error, undefined, 2)));
       ok(clcFake.red.getCall(2).calledWithExactly(runtimeErrors[1].browser.name));
-      ok(clcFake.red.getCall(3).calledWithExactly(runtimeErrors[1].error));
+      ok(clcFake.red.getCall(3).calledWithExactly(JSON.stringify(runtimeErrors[1].error, undefined, 2)));
     });
   });
 


### PR DESCRIPTION
Use `JSON.stringify` to get the full object printed.

Attempts to fix #41.