### PR TITLE
Add suppressBrowserLogs option to prevent the final printing of browser console log

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Here is a screenshot of the error and logging output. The errors are displayed h
 Options
 =========
 
-If you want to suppress the stack trace at the end of the test run you can use the suppressErrorReport option.
+If you want to suppress the stack trace at the end of the test run you can use the suppressErrorReport option. If you want to suppress the browser console log at the end of the test run you can use the suppressBrowserLogs option.
 
 ```js
 // karma.conf.js
@@ -56,6 +56,9 @@ module.exports = function(config) {
       // suppress the red background on errors in the error
       // report at the end of the test run
       suppressErrorHighlighting: true, // default is false
+
+      // suppress the browser console log at the end of the test run
+      suppressBrowserLogs: true, // default is false
 
       // increase the number of rainbow lines displayed
       // enforced min = 4, enforced max = terminal height - 1

--- a/lib/nyanCat.js
+++ b/lib/nyanCat.js
@@ -18,6 +18,7 @@ function NyanCat(baseReporterDecorator, formatError, config) {
     return {
       suppressErrorReport: false,
       suppressErrorHighlighting: false,
+      suppressBrowserLogs: false,
       numberOfRainbowLines: 4,
       renderOnRunCompleteOnly: false
     };
@@ -175,7 +176,9 @@ NyanCat.prototype.onRunComplete = function() {
     this.drawUtil.fillWithNewlines();
     printers.printTestFailures(this.dataStore.getData(), this.options.suppressErrorReport);
     printers.printStats(this.stats);
-    printers.printBrowserLogs(this.browser_logs);
+    if (!this.options.suppressBrowserLogs) {
+      printers.printBrowserLogs(this.browser_logs);
+    }
   }
   shellUtil.cursor.show();
 };


### PR DESCRIPTION
If the logs are not interesting, they push away the important test failures logged before them.

Attempts to fix #42.